### PR TITLE
Fix handling of command line properties with slashes

### DIFF
--- a/app/src/main/kotlin/com/developerphil/gww/ArgsConverter.kt
+++ b/app/src/main/kotlin/com/developerphil/gww/ArgsConverter.kt
@@ -13,6 +13,10 @@ private fun convertPathsToGradleCoordinates(arg: String, separator: String): Str
         return arg
     }
 
+    if (arg.startsWith("-P") || arg.startsWith("-D")) {
+        return arg
+    }
+
     val taskSeparator = "$separator$separator"
     if (arg.contains(taskSeparator)) {
 

--- a/app/src/test/kotlin/com/developerphil/gww/ArgsConverterTest.kt
+++ b/app/src/test/kotlin/com/developerphil/gww/ArgsConverterTest.kt
@@ -35,13 +35,24 @@ class ArgsConverterTest {
         "\"hello/world\"" parsesTo "\"hello/world\""
     }
 
-
     @Test
     fun `Join paths and task names when multiple tasks are provided for the same path`() {
         "feature/login:clean//assembleDebug" parsesTo ":feature:login:clean :feature:login:assembleDebug"
         "feature/login:clean//assembleDebug//test" parsesTo ":feature:login:clean :feature:login:assembleDebug :feature:login:test"
         "assembleDebug//test" parsesTo "assembleDebug test"
     }
+
+    @Test
+    fun `Parameters with slashes aren't parsed as project coordinates`() {
+        "-PgitBranch=origin/develop" parsesTo "-PgitBranch=origin/develop"
+        "clean assemble -PgitBranch=origin/develop" parsesTo "clean assemble -PgitBranch=origin/develop"
+        "app:assembleDebug -PgitBranch=origin/develop" parsesTo ":app:assembleDebug -PgitBranch=origin/develop"
+        ":app:assembleDebug -PgitBranch=origin/develop" parsesTo ":app:assembleDebug -PgitBranch=origin/develop"
+        "feature/login:assembleDebug -PgitBranch=origin/develop" parsesTo ":feature:login:assembleDebug -PgitBranch=origin/develop"
+        "feature/login/test-support:assembleDebug -PgitBranch=origin/develop" parsesTo ":feature:login:test-support:assembleDebug -PgitBranch=origin/develop"
+        "feature/login/test-support:assembleDebug -Dorg.gradle.debug=true -PgitBranch=origin/develop" parsesTo ":feature:login:test-support:assembleDebug -Dorg.gradle.debug=true -PgitBranch=origin/develop"
+    }
+
     private infix fun String.parsesTo(expected: String) {
         val argsArray = this.split(" ").toTypedArray()
         assertThat(argsArray.parseArguments(unixFileSystem())).isEqualTo(expected)


### PR DESCRIPTION
First of all, thanks for the project. It's been great.

Gww is currently unable to handle command line properties that have slashes in them. A command like `gww taskName -PgitBranch=origin/develop` will be interpreted as `gww taskName :-PgitBranch=origin:main`. This PR special cases both `-P` and `-D` arguments to ensure they aren't ever interpreted as anything but properties.